### PR TITLE
fix: add grpc server shutdown

### DIFF
--- a/pkg/function/example/forward_msg/server/main.go
+++ b/pkg/function/example/forward_msg/server/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"log"
+	"os"
 
 	functionsdk "github.com/numaproj/numaflow-go/pkg/function"
 	"github.com/numaproj/numaflow-go/pkg/function/server"
@@ -13,5 +15,13 @@ func handle(ctx context.Context, key string, msg []byte) (functionsdk.Messages, 
 }
 
 func main() {
-	server.New().RegisterMapper(functionsdk.DoFunc(handle)).Start()
+	file, _ := os.CreateTemp("/tmp", "numaflow-test.sock")
+	defer func() {
+		os.Remove(file.Name())
+		log.Println("clean up sock")
+	}()
+
+	server.New().RegisterMapper(functionsdk.DoFunc(handle)).Start(server.WithSockAddr("/tmp/numaflow-test.sock"))
+
+	log.Println("Exit")
 }

--- a/pkg/function/example/forward_msg/server/main.go
+++ b/pkg/function/example/forward_msg/server/main.go
@@ -13,5 +13,5 @@ func handle(ctx context.Context, key string, msg []byte) (functionsdk.Messages, 
 }
 
 func main() {
-	server.New().RegisterMapper(functionsdk.DoFunc(handle)).Start()
+	server.New().RegisterMapper(functionsdk.DoFunc(handle)).Start(context.Background())
 }

--- a/pkg/function/example/forward_msg/server/main.go
+++ b/pkg/function/example/forward_msg/server/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"log"
-	"os"
 
 	functionsdk "github.com/numaproj/numaflow-go/pkg/function"
 	"github.com/numaproj/numaflow-go/pkg/function/server"
@@ -15,13 +13,5 @@ func handle(ctx context.Context, key string, msg []byte) (functionsdk.Messages, 
 }
 
 func main() {
-	file, _ := os.CreateTemp("/tmp", "numaflow-test.sock")
-	defer func() {
-		os.Remove(file.Name())
-		log.Println("clean up sock")
-	}()
-
-	server.New().RegisterMapper(functionsdk.DoFunc(handle)).Start(server.WithSockAddr("/tmp/numaflow-test.sock"))
-
-	log.Println("Exit")
+	server.New().RegisterMapper(functionsdk.DoFunc(handle)).Start()
 }

--- a/pkg/function/server/server.go
+++ b/pkg/function/server/server.go
@@ -77,7 +77,7 @@ func (s *server) Start(inputOptions ...Option) {
 	case s := <-sigterm:
 		log.Printf("Got a signal [%s] Terminating gRPC server...\n", s)
 
-		grpcSvr.Stop()
+		grpcSvr.GracefulStop()
 		log.Println("Successfully Stopped the gRPC server")
 	}
 }

--- a/pkg/function/server/server.go
+++ b/pkg/function/server/server.go
@@ -75,7 +75,7 @@ func (s *server) Start(ctx context.Context, inputOptions ...Option) {
 	}()
 
 	<-ctxWithSignal.Done()
-	log.Printf("Got a signal: terminating gRPC server...")
-	defer log.Println("Successfully Stopped the gRPC server")
+	log.Println("Got a signal: terminating gRPC server...")
+	defer log.Println("Successfully stopped the gRPC server")
 	grpcSvr.GracefulStop()
 }

--- a/pkg/function/server/server.go
+++ b/pkg/function/server/server.go
@@ -75,9 +75,9 @@ func (s *server) Start(inputOptions ...Option) {
 	select {
 	// wait until we get a signal
 	case s := <-sigterm:
-		log.Printf("Got a signal [%s] Terminating...\n", s)
+		log.Printf("Got a signal [%s] Terminating gRPC server...\n", s)
 
 		grpcSvr.Stop()
-		log.Println("Successfully Stopped the CPD gRPC server")
+		log.Println("Successfully Stopped the gRPC server")
 	}
 }

--- a/pkg/function/server/server_test.go
+++ b/pkg/function/server/server_test.go
@@ -41,7 +41,7 @@ func Test_server_Start(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// note: using actual UDS connection
 
-			go New().RegisterMapper(tt.fields.mapHandler).Start(WithSockAddr(file.Name()))
+			go New().RegisterMapper(tt.fields.mapHandler).Start(context.Background(), WithSockAddr(file.Name()))
 
 			var ctx = context.Background()
 			c, err := client.New(client.WithSockAddr(file.Name()))


### PR DESCRIPTION
Signed-off-by: jyu6 <juanlu_yu@intuit.com>

fixes #6 

Testing
1.
```go
func main() {

	file, _ := os.CreateTemp("/tmp", "numaflow-test.sock")
	defer func() {
		os.Remove(file.Name())
		log.Println("clean up sock")
	}()

	var ctx, cancel = context.WithCancel(context.Background())
	go func() {
		time.Sleep(5 * time.Second)
		log.Println("cancelling ctx...")
		cancel()
	}()

	server.New().RegisterMapper(functionsdk.DoFunc(handle)).Start(ctx, server.WithSockAddr("/tmp/numaflow-test.sock"))

	log.Println("Exit")
}
```
<img width="1065" alt="image" src="https://user-images.githubusercontent.com/19543684/187266957-66f80cd9-a833-45d8-a0d0-9d6e15b2e936.png">

2. same main func but sent user interrupt
<img width="753" alt="image" src="https://user-images.githubusercontent.com/19543684/187267174-aca22266-4987-4361-9f12-f83a47f3ec5f.png">

