### PR TITLE
refactor: return error for server start

### DIFF
--- a/pkg/function/server/server.go
+++ b/pkg/function/server/server.go
@@ -117,6 +117,7 @@ func (s *server) Start(ctx context.Context, inputOptions ...Option) error {
 	functionpb.RegisterUserDefinedFunctionServer(grpcServer, s.svc)
 
 	errCh := make(chan error, 1)
+	defer close(errCh)
 	// start the grpc server
 	go func(ch chan<- error) {
 		log.Println("starting the gRPC server with unix domain socket...")

--- a/pkg/function/server/server.go
+++ b/pkg/function/server/server.go
@@ -128,7 +128,7 @@ func (s *server) Start(ctx context.Context, inputOptions ...Option) {
 	grpcServer.GracefulStop()
 }
 
-// StartE starts the gRPC server via unix domain socket at configs.Addr and return errors.
+// StartE starts the gRPC server via unix domain socket at configs.Addr and return error.
 func (s *server) StartE(ctx context.Context, inputOptions ...Option) error {
 	var opts = &options{
 		sockAddr:       functionsdk.Addr,

--- a/pkg/function/server/server.go
+++ b/pkg/function/server/server.go
@@ -114,6 +114,8 @@ func (s *server) Start(ctx context.Context, inputOptions ...Option) error {
 		grpc.MaxRecvMsgSize(opts.maxMessageSize),
 		grpc.MaxSendMsgSize(opts.maxMessageSize),
 	)
+	defer log.Println("Successfully stopped the gRPC server")
+	defer grpcServer.GracefulStop()
 	functionpb.RegisterUserDefinedFunctionServer(grpcServer, s.svc)
 
 	errCh := make(chan error, 1)
@@ -136,7 +138,5 @@ func (s *server) Start(ctx context.Context, inputOptions ...Option) error {
 		log.Println("Got a signal: terminating gRPC server...")
 	}
 
-	defer log.Println("Successfully stopped the gRPC server")
-	grpcServer.GracefulStop()
 	return nil
 }

--- a/pkg/function/server/server.go
+++ b/pkg/function/server/server.go
@@ -80,56 +80,8 @@ func (s *server) RegisterReducer(r functionsdk.ReduceHandler) *server {
 	return s
 }
 
-// Start starts the gRPC server via unix domain socket at configs.Addr.
-func (s *server) Start(ctx context.Context, inputOptions ...Option) {
-	var opts = &options{
-		sockAddr:       functionsdk.Addr,
-		maxMessageSize: functionsdk.DefaultMaxMessageSize,
-	}
-
-	for _, inputOption := range inputOptions {
-		inputOption(opts)
-	}
-
-	cleanup := func() {
-		if _, err := os.Stat(opts.sockAddr); err == nil {
-			if err := os.RemoveAll(opts.sockAddr); err != nil {
-				log.Fatal(err)
-			}
-		}
-	}
-	cleanup()
-
-	ctxWithSignal, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
-
-	lis, err := net.Listen(functionsdk.Protocol, opts.sockAddr)
-	if err != nil {
-		log.Fatalf("failed to execute net.Listen(%q, %q): %v", functionsdk.Protocol, functionsdk.Addr, err)
-	}
-	grpcServer := grpc.NewServer(
-		grpc.MaxRecvMsgSize(opts.maxMessageSize),
-		grpc.MaxSendMsgSize(opts.maxMessageSize),
-	)
-	functionpb.RegisterUserDefinedFunctionServer(grpcServer, s.svc)
-
-	// start the grpc server
-	go func() {
-		log.Println("starting the gRPC server with unix domain socket...")
-		err = grpcServer.Serve(lis)
-		if err != nil {
-			log.Fatalf("failed to start the gRPC server: %v", err)
-		}
-	}()
-
-	<-ctxWithSignal.Done()
-	log.Println("Got a signal: terminating gRPC server...")
-	defer log.Println("Successfully stopped the gRPC server")
-	grpcServer.GracefulStop()
-}
-
-// StartE starts the gRPC server via unix domain socket at configs.Addr and return error.
-func (s *server) StartE(ctx context.Context, inputOptions ...Option) error {
+// Start starts the gRPC server via unix domain socket at configs.Addr and return error.
+func (s *server) Start(ctx context.Context, inputOptions ...Option) error {
 	var opts = &options{
 		sockAddr:       functionsdk.Addr,
 		maxMessageSize: functionsdk.DefaultMaxMessageSize,

--- a/pkg/function/server/server.go
+++ b/pkg/function/server/server.go
@@ -92,11 +92,11 @@ func (s *server) Start(ctx context.Context, inputOptions ...Option) error {
 	}
 
 	cleanup := func() error {
-		_, err := os.Stat(opts.sockAddr)
-		if err == nil {
-			err = os.RemoveAll(opts.sockAddr)
+		// err if no opts.sockAddr should be ignored
+		if _, err := os.Stat(opts.sockAddr); err == nil {
+			return os.RemoveAll(opts.sockAddr)
 		}
-		return err
+		return nil
 	}
 
 	if err := cleanup(); err != nil {

--- a/pkg/function/server/server.go
+++ b/pkg/function/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net"
 	"os"
@@ -98,7 +99,7 @@ func (s *server) Start(ctx context.Context, inputOptions ...Option) error {
 		return err
 	}
 
-        if err := cleanup(); err != nil {
+	if err := cleanup(); err != nil {
 		return err
 	}
 

--- a/pkg/function/server/server.go
+++ b/pkg/function/server/server.go
@@ -98,8 +98,7 @@ func (s *server) Start(ctx context.Context, inputOptions ...Option) error {
 		return err
 	}
 
-	err := cleanup()
-	if err != nil {
+        if err := cleanup(); err != nil {
 		return err
 	}
 
@@ -108,7 +107,7 @@ func (s *server) Start(ctx context.Context, inputOptions ...Option) error {
 
 	lis, err := net.Listen(functionsdk.Protocol, opts.sockAddr)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to execute net.Listen(%q, %q): %v", functionsdk.Protocol, functionsdk.Addr, err)
 	}
 	grpcServer := grpc.NewServer(
 		grpc.MaxRecvMsgSize(opts.maxMessageSize),
@@ -125,7 +124,7 @@ func (s *server) Start(ctx context.Context, inputOptions ...Option) error {
 		log.Println("starting the gRPC server with unix domain socket...")
 		err = grpcServer.Serve(lis)
 		if err != nil {
-			ch <- err
+			ch <- fmt.Errorf("failed to start the gRPC server: %v", err)
 		}
 	}(errCh)
 

--- a/pkg/function/server/server.go
+++ b/pkg/function/server/server.go
@@ -116,7 +116,7 @@ func (s *server) Start(ctx context.Context, inputOptions ...Option) error {
 	)
 	functionpb.RegisterUserDefinedFunctionServer(grpcServer, s.svc)
 
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	// start the grpc server
 	go func(ch chan error) {
 		log.Println("starting the gRPC server with unix domain socket...")

--- a/pkg/function/server/server.go
+++ b/pkg/function/server/server.go
@@ -118,7 +118,7 @@ func (s *server) Start(ctx context.Context, inputOptions ...Option) error {
 
 	errCh := make(chan error, 1)
 	// start the grpc server
-	go func(ch chan error) {
+	go func(ch chan<- error) {
 		log.Println("starting the gRPC server with unix domain socket...")
 		err = grpcServer.Serve(lis)
 		if err != nil {

--- a/pkg/sink/server/server.go
+++ b/pkg/sink/server/server.go
@@ -57,11 +57,11 @@ func (s *server) Start(ctx context.Context, inputOptions ...Option) error {
 	}
 
 	cleanup := func() error {
-		_, err := os.Stat(opts.sockAddr)
-		if err == nil {
-			err = os.RemoveAll(opts.sockAddr)
+		// err if no opts.sockAddr should be ignored
+		if _, err := os.Stat(opts.sockAddr); err == nil {
+			return os.RemoveAll(opts.sockAddr)
 		}
-		return err
+		return nil
 	}
 
 	if err := cleanup(); err != nil {

--- a/pkg/sink/server/server.go
+++ b/pkg/sink/server/server.go
@@ -93,7 +93,7 @@ func (s *server) Start(ctx context.Context, inputOptions ...Option) {
 	grpcServer.GracefulStop()
 }
 
-// Start starts the gRPC server via unix domain socket at configs.Addr.
+// StartE starts the gRPC server via unix domain socket at configs.Addr and return error.
 func (s *server) StartE(ctx context.Context, inputOptions ...Option) error {
 	var opts = &options{
 		sockAddr:       sinksdk.Addr,


### PR DESCRIPTION
Return error instead of log.Fatal, fix #35 