### PR TITLE
refactor: un-export MessageT's attributes

### DIFF
--- a/pkg/function/examples/event_time_filter/impl/filter_test.go
+++ b/pkg/function/examples/event_time_filter/impl/filter_test.go
@@ -61,33 +61,21 @@ func Test_FilterEventTime(t *testing.T) {
 			name:  "DatumWithEventTimeBefore2022GetsDropped",
 			input: beforeYear2022Datum{},
 			expectedOutput: functionsdk.MessageTs{
-				functionsdk.MessageT{
-					EventTime: time.Time{},
-					Key:       functionsdk.DROP,
-					Value:     []byte{},
-				},
+				functionsdk.MessageTToDrop(),
 			},
 		},
 		{
 			name:  "DatumWithEventTimeWithin2022GetsKeyAndEventTimeUpdated",
 			input: withinYear2022Datum{},
 			expectedOutput: functionsdk.MessageTs{
-				functionsdk.MessageT{
-					EventTime: janFisrt2022,
-					Key:       "within_year_2022",
-					Value:     []byte("test-data"),
-				},
+				functionsdk.MessageTTo(janFisrt2022, "within_year_2022", []byte("test-data")),
 			},
 		},
 		{
 			name:  "DatumWithEventTimeAfter2022GetsKeyAndEventTimeUpdated",
 			input: afterYear2022Datum{},
 			expectedOutput: functionsdk.MessageTs{
-				functionsdk.MessageT{
-					EventTime: janFirst2023,
-					Key:       "after_year_2022",
-					Value:     []byte("test-data"),
-				},
+				functionsdk.MessageTTo(janFirst2023, "after_year_2022", []byte("test-data")),
 			},
 		},
 	}

--- a/pkg/function/message.go
+++ b/pkg/function/message.go
@@ -9,23 +9,23 @@ var (
 
 // Message is used to wrap the data return by UDF functions
 type Message struct {
-	Key   string
-	Value []byte
+	key   string
+	value []byte
 }
 
 // MessageToDrop creates a Message to be dropped
 func MessageToDrop() Message {
-	return Message{Key: DROP, Value: []byte{}}
+	return Message{key: DROP, value: []byte{}}
 }
 
 // MessageToAll creates a Message that will forward to all
 func MessageToAll(value []byte) Message {
-	return Message{Key: ALL, Value: value}
+	return Message{key: ALL, value: value}
 }
 
 // MessageTo creates a Message that will forward to specified "to"
 func MessageTo(to string, value []byte) Message {
-	return Message{Key: to, Value: value}
+	return Message{key: to, value: value}
 }
 
 type Messages []Message

--- a/pkg/function/message_t.go
+++ b/pkg/function/message_t.go
@@ -7,24 +7,24 @@ import (
 // MessageT is used to wrap the data return by UDF functions.
 // Compared with Message, MessageT contains one more field, the event time, usually extracted from the payload.
 type MessageT struct {
-	EventTime time.Time
-	Key       string
-	Value     []byte
+	eventTime time.Time
+	key       string
+	value     []byte
 }
 
 // MessageTToDrop creates a MessageT to be dropped
 func MessageTToDrop() MessageT {
-	return MessageT{EventTime: time.Time{}, Key: DROP, Value: []byte{}}
+	return MessageT{eventTime: time.Time{}, key: DROP, value: []byte{}}
 }
 
 // MessageTToAll creates a MessageT that will forward to all
 func MessageTToAll(eventTime time.Time, value []byte) MessageT {
-	return MessageT{EventTime: eventTime, Key: ALL, Value: value}
+	return MessageT{eventTime: eventTime, key: ALL, value: value}
 }
 
 // MessageTTo creates a MessageT that will forward to specified "to"
 func MessageTTo(eventTime time.Time, to string, value []byte) MessageT {
-	return MessageT{EventTime: eventTime, Key: to, Value: value}
+	return MessageT{eventTime: eventTime, key: to, value: value}
 }
 
 type MessageTs []MessageT

--- a/pkg/function/server/server_test.go
+++ b/pkg/function/server/server_test.go
@@ -9,12 +9,13 @@ import (
 	"testing"
 	"time"
 
-	functionpb "github.com/numaproj/numaflow-go/pkg/apis/proto/function/v1"
-	functionsdk "github.com/numaproj/numaflow-go/pkg/function"
-	"github.com/numaproj/numaflow-go/pkg/function/client"
 	"github.com/stretchr/testify/assert"
 	grpcmd "google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	functionpb "github.com/numaproj/numaflow-go/pkg/apis/proto/function/v1"
+	functionsdk "github.com/numaproj/numaflow-go/pkg/function"
+	"github.com/numaproj/numaflow-go/pkg/function/client"
 )
 
 type fields struct {
@@ -211,14 +212,14 @@ func Test_server_reduce(t *testing.T) {
 			// set the key in gPRC metadata for reduce function
 			md := grpcmd.New(map[string]string{functionsdk.DatumKey: testKey, functionsdk.WinStartTime: "60000", functionsdk.WinEndTime: "120000"})
 			ctx = grpcmd.NewOutgoingContext(ctx, md)
-			resultChan, err := c.ReduceFn(ctx, reduceDatumCh)
+			resultDatumList, err := c.ReduceFn(ctx, reduceDatumCh)
 			var wg sync.WaitGroup
 
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				for res := range resultChan {
-					dList.Elements = append(dList.Elements, res.Elements...)
+				for _, d := range resultDatumList {
+					dList.Elements = append(dList.Elements, d)
 				}
 			}()
 

--- a/pkg/function/service.go
+++ b/pkg/function/service.go
@@ -8,11 +8,12 @@ import (
 	"sync"
 	"time"
 
-	functionpb "github.com/numaproj/numaflow-go/pkg/apis/proto/function/v1"
 	"golang.org/x/sync/errgroup"
 	grpcmd "google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	functionpb "github.com/numaproj/numaflow-go/pkg/apis/proto/function/v1"
 )
 
 // handlerDatum implements the Datum interface and is used in the map and reduce handlers.
@@ -139,13 +140,13 @@ func (fs *Service) MapTFn(ctx context.Context, d *functionpb.Datum) (*functionpb
 		eventTime: d.GetEventTime().EventTime.AsTime(),
 		watermark: d.GetWatermark().Watermark.AsTime(),
 	}
-	messages := fs.MapperT.HandleDo(ctx, key, &hd)
+	messageTs := fs.MapperT.HandleDo(ctx, key, &hd)
 	var elements []*functionpb.Datum
-	for _, m := range messages.Items() {
+	for _, m := range messageTs.Items() {
 		elements = append(elements, &functionpb.Datum{
-			EventTime: &functionpb.EventTime{EventTime: timestamppb.New(m.EventTime)},
-			Key:       m.Key,
-			Value:     m.Value,
+			EventTime: &functionpb.EventTime{EventTime: timestamppb.New(m.eventTime)},
+			Key:       m.key,
+			Value:     m.value,
 		})
 	}
 	datumList := &functionpb.DatumList{

--- a/pkg/function/service.go
+++ b/pkg/function/service.go
@@ -108,8 +108,8 @@ func (fs *Service) MapFn(ctx context.Context, d *functionpb.Datum) (*functionpb.
 	var elements []*functionpb.Datum
 	for _, m := range messages.Items() {
 		elements = append(elements, &functionpb.Datum{
-			Key:   m.Key,
-			Value: m.Value,
+			Key:   m.key,
+			Value: m.value,
 		})
 	}
 	datumList := &functionpb.DatumList{
@@ -250,8 +250,8 @@ func buildDatumList(messages Messages) *functionpb.DatumList {
 	datumList := &functionpb.DatumList{}
 	for _, msg := range messages {
 		datumList.Elements = append(datumList.Elements, &functionpb.Datum{
-			Key:   msg.Key,
-			Value: msg.Value,
+			Key:   msg.key,
+			Value: msg.value,
 		})
 	}
 


### PR DESCRIPTION
In MapT, it's important to assign new event times to ensure that default time values are not mistakenly passed to the next vertex. While our MapT SDKs offer methods like MessageTToAll() and MessageTTo() to create MessageT objects with explicit event times, users can also construct MessageT objects from scratch. However, if they forget to assign a new event time while modifying other attributes, default time values may be used unintentionally. 

To reduce this risk, we propose always requiring an explicit event assignment for MapT implementation. This code change achieves the proposal by un-exporting MessageT's attributes.

After this change, user can only use the following constructors to create MessageT objects:

```
functionsdk.MessageTToDrop()
```

```
functionsdk.MessageTTo(eventTime, key, value)
```

```
functionsdk.MessageTToAll(eventTime, value)
```

### Following approaches to create MessageT objects are no longer allowed.

```
msgt := MessageT{EventTime: event_time, Key: key, Value: value}
```
```
msgt := MessageT{}
msgt.EventTime = event_time
...
```

**Also applied similar changes to Message**