### PR TITLE
chore: fix some typos

### DIFF
--- a/pkg/function/client/client.go
+++ b/pkg/function/client/client.go
@@ -9,15 +9,16 @@ import (
 	"runtime"
 	"strconv"
 
-	functionpb "github.com/numaproj/numaflow-go/pkg/apis/proto/function/v1"
-	"github.com/numaproj/numaflow-go/pkg/function"
-	"github.com/numaproj/numaflow-go/pkg/info"
 	_ "go.uber.org/automaxprocs"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	functionpb "github.com/numaproj/numaflow-go/pkg/apis/proto/function/v1"
+	"github.com/numaproj/numaflow-go/pkg/function"
+	"github.com/numaproj/numaflow-go/pkg/info"
 )
 
 // client contains the grpc connection and the grpc client.
@@ -29,8 +30,8 @@ type client struct {
 // New creates a new client object.
 func New(inputOptions ...Option) (*client, error) {
 	var opts = &options{
-		maxMessageSize:      function.DefaultMaxMessageSize,
-		sereverInfoFilePath: info.ServerInfoFilePath,
+		maxMessageSize:     function.DefaultMaxMessageSize,
+		serverInfoFilePath: info.ServerInfoFilePath,
 	}
 
 	// Populate connection variables for client connection
@@ -47,7 +48,7 @@ func New(inputOptions ...Option) (*client, error) {
 	}
 
 	// TODO: WaitUntilReady() check unitl SIGTERM is received.
-	serverInfo, err := info.Read(info.WithServerInfoFilePath(opts.sereverInfoFilePath))
+	serverInfo, err := info.Read(info.WithServerInfoFilePath(opts.serverInfoFilePath))
 	if err != nil {
 		// TODO: return nil, err
 		log.Println("Failed to execute info.Read(): ", err)

--- a/pkg/function/client/options.go
+++ b/pkg/function/client/options.go
@@ -1,9 +1,9 @@
 package client
 
 type options struct {
-	sockAddr            string
-	maxMessageSize      int
-	sereverInfoFilePath string
+	sockAddr           string
+	maxMessageSize     int
+	serverInfoFilePath string
 }
 
 // Option is the interface to apply options.
@@ -26,6 +26,6 @@ func WithMaxMessageSize(size int) Option {
 // WithServerInfoFilePath sets the server info file path to the given path.
 func WithServerInfoFilePath(f string) Option {
 	return func(o *options) {
-		o.sereverInfoFilePath = f
+		o.serverInfoFilePath = f
 	}
 }

--- a/pkg/function/server/server_test.go
+++ b/pkg/function/server/server_test.go
@@ -50,7 +50,6 @@ func Test_server_map(t *testing.T) {
 	}()
 
 	serverInfoFile, err := os.CreateTemp("/tmp", "numaflow-test-info")
-	fmt.Println(serverInfoFile.Name())
 	assert.NoError(t, err)
 	defer func() {
 		err = os.RemoveAll(serverInfoFile.Name())

--- a/pkg/info/server_info.go
+++ b/pkg/info/server_info.go
@@ -50,7 +50,7 @@ func Write(svrInfo *ServerInfo, opts ...Option) error {
 	if err != nil {
 		return fmt.Errorf("failed to write server-info file: %w", err)
 	}
-	_, err = f.WriteString(END)
+	_, err = f.WriteString(fmt.Sprintf("\n%s", END))
 	if err != nil {
 		return fmt.Errorf("failed to write END server-info file: %w", err)
 	}
@@ -102,7 +102,7 @@ func Read(opts ...Option) (*ServerInfo, error) {
 	if !strings.HasSuffix(string(b), END) {
 		return nil, fmt.Errorf("server info file is not ready")
 	}
-	b = b[:len(b)-len([]byte(END))]
+	b = b[:len(b)-len([]byte(fmt.Sprintf("\n%s", END)))]
 	info := &ServerInfo{}
 	if err := json.Unmarshal(b, info); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal server info: %w", err)

--- a/pkg/info/server_info.go
+++ b/pkg/info/server_info.go
@@ -50,7 +50,7 @@ func Write(svrInfo *ServerInfo, opts ...Option) error {
 	if err != nil {
 		return fmt.Errorf("failed to write server-info file: %w", err)
 	}
-	_, err = f.WriteString(fmt.Sprintf("\n%s", END))
+	_, err = f.WriteString(END)
 	if err != nil {
 		return fmt.Errorf("failed to write END server-info file: %w", err)
 	}
@@ -102,7 +102,7 @@ func Read(opts ...Option) (*ServerInfo, error) {
 	if !strings.HasSuffix(string(b), END) {
 		return nil, fmt.Errorf("server info file is not ready")
 	}
-	b = b[:len(b)-len([]byte(fmt.Sprintf("\n%s", END)))]
+	b = b[:len(b)-len([]byte(END))]
 	info := &ServerInfo{}
 	if err := json.Unmarshal(b, info); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal server info: %w", err)

--- a/pkg/info/server_info_test.go
+++ b/pkg/info/server_info_test.go
@@ -52,9 +52,14 @@ func Test_WaitUntilReady(t *testing.T) {
 }
 
 func Test_Read_Write(t *testing.T) {
-	filepath := os.TempDir() + "/server-info"
+	filepath := os.TempDir() + "server-info"
 	defer os.Remove(filepath)
-	info := &ServerInfo{Protocol: UDS, Language: Go, Version: ""}
+	info := &ServerInfo{
+		Protocol: TCP,
+		Language: Java,
+		Version:  "11",
+		Metadata: map[string]string{"key1": "value1", "key2": "value2"},
+	}
 	err := Write(info, WithServerInfoFilePath(filepath))
 	assert.NoError(t, err)
 	got, err := Read(WithServerInfoFilePath("/tmp/not-exist"))

--- a/pkg/info/types.go
+++ b/pkg/info/types.go
@@ -21,8 +21,8 @@ const (
 
 // ServerInfo is the information about the server
 type ServerInfo struct {
-	Protocol  Protocol          `json:"protocol"`
-	Language  Language          `json:"language"`
-	Version   string            `json:"version"`
-	Metaddata map[string]string `json:"metadata"`
+	Protocol Protocol          `json:"protocol"`
+	Language Language          `json:"language"`
+	Version  string            `json:"version"`
+	Metadata map[string]string `json:"metadata"`
 }


### PR DESCRIPTION
In my recent [Java implementation](https://github.com/numaproj/numaflow-java/pull/36), I write the EOF on a newline, just to make it a bit clearer. I make the same changes here in Go SDK to make it consistent for parsing.