### PR TITLE
chore: update map stream interface

### DIFF
--- a/pkg/function/client/client.go
+++ b/pkg/function/client/client.go
@@ -114,7 +114,7 @@ func (c *client) MapFn(ctx context.Context, datum *functionpb.DatumRequest) ([]*
 }
 
 // MapStreamFn applies a function to each datum element and returns a stream.
-func (c *client) MapStreamFn(ctx context.Context, datum *functionpb.DatumRequest, datumCh chan<- functionpb.DatumResponse) error {
+func (c *client) MapStreamFn(ctx context.Context, datum *functionpb.DatumRequest, datumCh chan<- *functionpb.DatumResponse) error {
 	defer close(datumCh)
 	stream, err := c.grpcClt.MapStreamFn(ctx, datum)
 	if err != nil {
@@ -134,7 +134,7 @@ func (c *client) MapStreamFn(ctx context.Context, datum *functionpb.DatumRequest
 			if err != nil {
 				return err
 			}
-			datumCh <- *resp
+			datumCh <- resp
 		}
 	}
 

--- a/pkg/function/clienttest/client_test.go
+++ b/pkg/function/clienttest/client_test.go
@@ -134,7 +134,7 @@ func TestMapStreamFn(t *testing.T) {
 		grpcClt: mockClient,
 	})
 
-	datumCh := make(chan functionpb.DatumResponse)
+	datumCh := make(chan *functionpb.DatumResponse)
 	datumResponses := make([]*functionpb.DatumResponse, 0)
 
 	go func() {
@@ -143,7 +143,7 @@ func TestMapStreamFn(t *testing.T) {
 	}()
 
 	for msg := range datumCh {
-		datumResponses = append(datumResponses, &msg)
+		datumResponses = append(datumResponses, msg)
 	}
 	assert.True(t, reflect.DeepEqual(datumResponses, []*functionpb.DatumResponse{expectedDatum}))
 }

--- a/pkg/function/clienttest/clienttest.go
+++ b/pkg/function/clienttest/clienttest.go
@@ -46,7 +46,7 @@ func (c *client) MapFn(ctx context.Context, datum *functionpb.DatumRequest) ([]*
 }
 
 // MapStreamFn applies a function to each datum element and returns a stream.
-func (c *client) MapStreamFn(ctx context.Context, datum *functionpb.DatumRequest, datumCh chan<- functionpb.DatumResponse) error {
+func (c *client) MapStreamFn(ctx context.Context, datum *functionpb.DatumRequest, datumCh chan<- *functionpb.DatumResponse) error {
 	defer close(datumCh)
 	stream, err := c.grpcClt.MapStreamFn(ctx, datum)
 	if err != nil {
@@ -56,7 +56,7 @@ func (c *client) MapStreamFn(ctx context.Context, datum *functionpb.DatumRequest
 	for {
 		select {
 		case <-ctx.Done():
-			err = ctx.Err()
+			return ctx.Err()
 		default:
 			var resp *functionpb.DatumResponse
 			resp, err = stream.Recv()
@@ -66,7 +66,7 @@ func (c *client) MapStreamFn(ctx context.Context, datum *functionpb.DatumRequest
 			if err != nil {
 				return err
 			}
-			datumCh <- *resp
+			datumCh <- resp
 		}
 	}
 

--- a/pkg/function/interface.go
+++ b/pkg/function/interface.go
@@ -40,7 +40,7 @@ type Client interface {
 	CloseConn(ctx context.Context) error
 	IsReady(ctx context.Context, in *emptypb.Empty) (bool, error)
 	MapFn(ctx context.Context, datum *functionpb.DatumRequest) ([]*functionpb.DatumResponse, error)
-	MapStreamFn(ctx context.Context, datum *functionpb.DatumRequest, datumCh chan<- functionpb.DatumResponse) error
+	MapStreamFn(ctx context.Context, datum *functionpb.DatumRequest, datumCh chan<- *functionpb.DatumResponse) error
 	MapTFn(ctx context.Context, datum *functionpb.DatumRequest) ([]*functionpb.DatumResponse, error)
 	ReduceFn(ctx context.Context, datumStreamCh <-chan *functionpb.DatumRequest) ([]*functionpb.DatumResponse, error)
 }

--- a/pkg/function/server/server_test.go
+++ b/pkg/function/server/server_test.go
@@ -162,7 +162,7 @@ func Test_server_map_stream(t *testing.T) {
 			for i := 0; i < 10; i++ {
 				keys := []string{fmt.Sprintf("client_%d", i)}
 
-				datumCh := make(chan functionpb.DatumResponse)
+				datumCh := make(chan *functionpb.DatumResponse)
 				go func() {
 					err := c.MapStreamFn(ctx, &functionpb.DatumRequest{
 						Keys:      keys,


### PR DESCRIPTION
This PR updates the newly added map stream interface from `MapStreamFn(ctx context.Context, datum *functionpb.DatumRequest, datumCh chan<- functionpb.DatumResponse) error` to `MapStreamFn(ctx context.Context, datum *functionpb.DatumRequest, datumCh chan<- *functionpb.DatumResponse) error`. 

Even though it is not recommended to use [pointers to channel](https://stackoverflow.com/questions/44351159/using-pointer-to-channel), without this change, when traverse from the client side response in numaflow, `go vet` will complain about:
> copylocks: range var datum copies lock: github.com/numaproj/numaflow-go/pkg/apis/proto/function/v1.DatumResponse contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex

See this [discussion](https://stackoverflow.com/questions/64183794/why-do-the-go-generated-protobuf-files-contain-mutex-locks) for reference about protobuf `impl.MessageState`. 