### PR TITLE
chore: remove duplicate functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,3 @@ proto:
 .PHONY: generate
 generate:
 	go generate ./...
-
-.PHONY: image-push-all
-image-push-all:
-	for dir in $(shell find ./pkg -name 'Makefile' -exec dirname {} \;); do \
-		$(MAKE) -C $$dir image-push TAG=$(TAG); \
-	done
-


### PR DESCRIPTION
This make target functionality is already implemented in the update script, can achieve the same result running:

`./hack/update_examples -bp -t test`