### PR TITLE
chore: remove unnecessary flag

### DIFF
--- a/development.md
+++ b/development.md
@@ -12,18 +12,13 @@ Each example directory has a Makefile which can be used to build, tag, and push 
 If you want to build and tag the image and then immediately push it to quay.io, use the `image-push` target.
 If you want to build and tag a local image without pushing, use the `image` target.
 
-If you want to build and push all the example images at once, you can run:
-```shell
-./hack/update_examples.sh -bp -t <tag>
-```
-The default tag is `stable`, but it is recommended you specify your own for testing purposes, as the Github Actions CI uses the `stable` tag.
-This consistent tag name is used so that the tags in the [E2E test pipelines](https://github.com/numaproj/numaflow/tree/main/test) do not need to be updated each time an SDK change is made.
-
-You can alternatively build and push a specific example image by running the following:
+You can build and push a specific example image by running the following:
 ```shell
 ./hack/update_examples.sh -bpe <path-to-dockerfile> -t <tag>
 ```
 This is essentially equivalent to running `make image-push TAG=<tag>` in the example directory itself.
+The default tag is `stable`, but it is recommended you specify your own for testing purposes, as the Github Actions CI uses the `stable` tag.
+This consistent tag name is used so that the tags in the [E2E test pipelines](https://github.com/numaproj/numaflow/tree/main/test) do not need to be updated each time an SDK change is made.
 
 Note: before running the script, ensure that through the CLI, you are logged into quay.io.
 

--- a/hack/update_examples.sh
+++ b/hack/update_examples.sh
@@ -4,7 +4,7 @@ function show_help () {
     echo "Usage: $0 [-h|--help | -t|--tag <tag>] (-bpe|--build-push-example <path> | -u|--update <SDK-version | commit-sha | latest >)"
     echo "  -h, --help                   Display help message and exit"
     echo "  -bpe, --build-push-example   Build the Dockerfile of the given example directory path, and push it to the quay.io registry"
-    echo "  -t, --tag                    To be optionally used with -bpe or -bp. Specify the tag to build with. Default tag: stable"
+    echo "  -t, --tag                    To be optionally used with -bpe. Specify the tag to build with. Default tag: stable"
     echo "  -u, --update                 Update all of the examples to depend on the numaflow-go version with the specified SHA or version"
 }
 

--- a/hack/update_examples.sh
+++ b/hack/update_examples.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 function show_help () {
-    echo "Usage: $0 [-h|--help | -t|--tag <tag>] (-bp|--build-push | -bpe|--build-push-example <path> | -u|--update <SDK-version | commit-sha | latest >)"
+    echo "Usage: $0 [-h|--help | -t|--tag <tag>] (-bpe|--build-push-example <path> | -u|--update <SDK-version | commit-sha | latest >)"
     echo "  -h, --help                   Display help message and exit"
-    echo "  -bp, --build-push            Build the Dockerfiles of all the examples and push them to the quay.io registry"
     echo "  -bpe, --build-push-example   Build the Dockerfile of the given example directory path, and push it to the quay.io registry"
     echo "  -t, --tag                    To be optionally used with -bpe or -bp. Specify the tag to build with. Default tag: stable"
     echo "  -u, --update                 Update all of the examples to depend on the numaflow-go version with the specified SHA or version"
@@ -34,7 +33,6 @@ if [ $# -eq 0 ]; then
 fi
 
 usingHelp=0
-usingBuildPush=0
 usingBuildPushExample=0
 usingVersion=0
 usingTag=0
@@ -47,9 +45,6 @@ function handle_options () {
     case "$1" in
       -h | --help)
         usingHelp=1
-        ;;
-      -bp | --build-push)
-        usingBuildPush=1
         ;;
       -bpe | --build-push-example)
         if [ -z "$2" ]; then
@@ -96,14 +91,14 @@ function handle_options () {
 
 handle_options "$@"
 
-if (( usingBuildPush + usingBuildPushExample + usingVersion + usingHelp > 1 )); then
-  echo "Only one of '-h', '-bp', '-bpe', or, '-u' is allowed at a time" >&2
+if (( usingBuildPushExample + usingVersion + usingHelp > 1 )); then
+  echo "Only one of '-h', '-bpe', or, '-u' is allowed at a time" >&2
   show_help
   exit 1
 fi
 
-if (( (usingTag + usingVersion + usingHelp > 1) || (usingTag && usingBuildPush + usingBuildPushExample == 0) )); then
-  echo "Can only use -t with -bp or -bpe" >&2
+if (( (usingTag + usingVersion + usingHelp > 1) || (usingTag && usingBuildPushExample == 0) )); then
+  echo "Can only use -t with -bpe" >&2
   show_help
   exit 1
 fi
@@ -120,9 +115,7 @@ if [ -n "$tag" ] && (( ! usingVersion )) && (( ! usingHelp )); then
  echo "Using tag: $tag"
 fi
 
-if (( usingBuildPush )); then
-  traverse_examples "make image-push TAG=$tag"
-elif (( usingBuildPushExample )); then
+if (( usingBuildPushExample )); then
    cd "./$directoryPath" || exit
    if ! make image-push TAG="$tag"; then
      echo "Error: failed to run make image-push in $directoryPath" >&2

--- a/releases.md
+++ b/releases.md
@@ -31,7 +31,7 @@ As a result, the correct SDK version will always be printed in the server inform
 and the example images will always be using the latest changes (due to the local references)
 3. Since the Go SDK is a dependency of Numaflow, once a new version has been released, the `go.mod` [file](https://github.com/numaproj/numaflow/blob/main/go.mod)
 in the Numaflow repo should be updated
-   - If you set the SDK release as latest, in your Numaflow repo run:
+   - If you set the SDK release as `latest`, in your Numaflow repo run:
         ```shell
          go get github.com/numaproj/numaflow-go@latest
         ``` 
@@ -40,7 +40,7 @@ in the Numaflow repo should be updated
         go mod tidy
         ```
         Create a PR for these changes
-   - If you set the SDK release as pre-release, in your Numaflow repo run:
+   - If you set the SDK release as `pre-release`, in your Numaflow repo run:
      ```shell
       go get github.com/numaproj/numaflow-go@<commit-sha>
       ``` 


### PR DESCRIPTION
It is very unlikely that anyone will ever need to build and push all the example images locally while testing. In order to clean up the script remove this functionality, as it should only be done by Github Actions workflow.
