### PR TITLE
fix: graceful shutdown in accumulator

### DIFF
--- a/pkg/accumulator/server.go
+++ b/pkg/accumulator/server.go
@@ -30,10 +30,12 @@ func NewServer(r AccumulatorCreator, inputOptions ...Option) numaflow.Server {
 	for _, inputOption := range inputOptions {
 		inputOption(opts)
 	}
+	shutdownCh := make(chan struct{})
+
 	s := new(server)
-	s.svc = new(Service)
-	s.svc.AccumulatorCreator = r
+	s.svc = NewService(r, shutdownCh)
 	s.opts = opts
+	s.shutdownCh = shutdownCh
 	return s
 }
 

--- a/pkg/accumulator/service.go
+++ b/pkg/accumulator/service.go
@@ -42,6 +42,15 @@ type Service struct {
 	shutdownCh         chan<- struct{}
 }
 
+// NewService creates a new accumulator service.
+func NewService(r AccumulatorCreator, shutdownCh chan<- struct{}) *Service {
+	return &Service{
+		AccumulatorCreator: r,
+		shutdownCh:         shutdownCh,
+		once:               sync.Once{},
+	}
+}
+
 // IsReady returns true to indicate the gRPC connection is ready.
 func (fs *Service) IsReady(context.Context, *emptypb.Empty) (*accumulatorpb.ReadyResponse, error) {
 	return &accumulatorpb.ReadyResponse{Ready: true}, nil


### PR DESCRIPTION
```
2025/03/28 01:54:12 Starting server
2025/03/28 01:54:13 Watermark updated, flushing sortedBuffer:  1743126495631
2025/03/28 01:54:13 panic inside accumulator handler: invalid data goroutine 28 [running]:
runtime/debug.Stack()
	/opt/homebrew/opt/go/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/numaproj/numaflow-go/pkg/accumulator.(*accumulatorTaskManager).CreateTask.func1.2()
	/Users/yhl01/Documents/numaproj/numaflow-go/pkg/accumulator/task_manager.go:138 +0x44
panic({0x451020?, 0x5c78e8?})
	/opt/homebrew/opt/go/libexec/src/runtime/panic.go:792 +0x124
main.(*streamSorter).Accumulate(0x40001965a0, {0x5ce590, 0x400021a1e0}, 0x4000242620, 0x4000242690)
	/Users/yhl01/Documents/numaproj/numaflow-go/pkg/accumulator/examples/streamsorter/main.go:38 +0x1ec
github.com/numaproj/numaflow-go/pkg/accumulator.(*accumulatorTaskManager).CreateTask.func1()
	/Users/yhl01/Documents/numaproj/numaflow-go/pkg/accumulator/task_manager.go:149 +0x11c
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/Users/yhl01/go/pkg/mod/golang.org/x/sync@v0.8.0/errgroup/errgroup.go:78 +0x54
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 21
	/Users/yhl01/go/pkg/mod/golang.org/x/sync@v0.8.0/errgroup/errgroup.go:75 +0x94
2025/03/28 01:54:13 Stopping the AccumulateFn with err, rpc error: code = Internal desc = UDF_EXECUTION_ERROR(udf): Watermark should not be updated
2025/03/28 01:54:13 received shutdown signal
2025/03/28 01:54:13 gracefully stopping grpc server
2025/03/28 01:54:13 grpc server stopped
```