### PR TITLE
fix: client cancellation should not trigger grpc shutdown

### DIFF
--- a/pkg/accumulator/service.go
+++ b/pkg/accumulator/service.go
@@ -106,7 +106,7 @@ func (fs *Service) AccumulateFn(stream accumulatorpb.Accumulator_AccumulateFnSer
 		}
 	}
 
-	// wait for all goroutines to finish
+	// wait for all goroutines to finish, ignore client cancellation errors
 	if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
 		fs.once.Do(func() {
 			log.Printf("Stopping the AccumulateFn with err, %s", err)

--- a/pkg/accumulator/service.go
+++ b/pkg/accumulator/service.go
@@ -83,7 +83,6 @@ func (fs *Service) AccumulateFn(stream accumulatorpb.Accumulator_AccumulateFnSer
 			break
 		}
 		if errors.Is(err, io.EOF) {
-			log.Printf("EOF received, stopping the AccumulateFn")
 			taskManager.CloseAll()
 			return nil
 		}
@@ -108,7 +107,7 @@ func (fs *Service) AccumulateFn(stream accumulatorpb.Accumulator_AccumulateFnSer
 	}
 
 	// wait for all goroutines to finish
-	if err := g.Wait(); err != nil {
+	if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
 		fs.once.Do(func() {
 			log.Printf("Stopping the AccumulateFn with err, %s", err)
 			fs.shutdownCh <- struct{}{}

--- a/pkg/batchmapper/service.go
+++ b/pkg/batchmapper/service.go
@@ -63,11 +63,7 @@ func (fs *Service) MapFn(stream mappb.Map_MapFnServer) error {
 		})
 
 		// Wait for the goroutines to finish
-		if err := g.Wait(); err != nil {
-			if errors.Is(err, io.EOF) {
-				log.Printf("Stopping the BatchMapFn")
-				return nil
-			}
+		if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
 			fs.once.Do(func() {
 				log.Printf("Stopping the BatchMapFn with err, %s", err)
 				fs.shutdownCh <- struct{}{}
@@ -133,8 +129,7 @@ func (fs *Service) receiveRequests(ctx context.Context, stream mappb.Map_MapFnSe
 			return err
 		}
 		if errors.Is(err, io.EOF) {
-			log.Printf("EOF received, stopping the MapBatchFn")
-			return err
+			return nil
 		}
 		if err != nil {
 			log.Printf("error receiving from batch map stream: %v", err)

--- a/pkg/mapper/service.go
+++ b/pkg/mapper/service.go
@@ -106,7 +106,6 @@ outer:
 			break outer
 		}
 		if errors.Is(err, io.EOF) {
-			log.Printf("EOF received, stopping the MapFn")
 			break outer
 		}
 		if err != nil {
@@ -123,7 +122,7 @@ outer:
 	}
 
 	// wait for all goroutines to finish
-	if err := g.Wait(); err != nil {
+	if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
 		fs.once.Do(func() {
 			log.Printf("Stopping the MapFn with err, %s", err)
 			fs.shutdownCh <- struct{}{}

--- a/pkg/mapstreamer/service.go
+++ b/pkg/mapstreamer/service.go
@@ -86,7 +86,6 @@ outer:
 			break outer
 		}
 		if errors.Is(err, io.EOF) {
-			log.Printf("EOF received, stopping the MapFn")
 			break outer
 		}
 		if err != nil {
@@ -100,21 +99,18 @@ outer:
 		g.Go(func() error {
 			messageCh := make(chan Message)
 			workerGroup, innerCtx := errgroup.WithContext(groupCtx)
-
 			workerGroup.Go(func() error {
 				return fs.invokeHandler(innerCtx, req, messageCh)
 			})
-
 			workerGroup.Go(func() error {
 				return fs.writeResponseToClient(innerCtx, stream, req.GetId(), messageCh)
 			})
-
 			return workerGroup.Wait()
 		})
 	}
 
 	// wait for all goroutines to finish
-	if err := g.Wait(); err != nil {
+	if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
 		fs.once.Do(func() {
 			log.Printf("Stopping the MapFn with err, %s", err)
 			fs.shutdownCh <- struct{}{}

--- a/pkg/reducer/service.go
+++ b/pkg/reducer/service.go
@@ -96,7 +96,6 @@ readLoop:
 			break
 		}
 		if errors.Is(err, io.EOF) {
-			log.Printf("EOF received, stopping the ReduceFn")
 			taskManager.CloseAll()
 			// wait for all tasks to complete and close output channel
 			taskManager.WaitAll()
@@ -140,7 +139,7 @@ readLoop:
 	}
 
 	// wait for all goroutines to finish
-	if err := g.Wait(); err != nil {
+	if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
 		fs.once.Do(func() {
 			log.Printf("Stopping the ReduceFn with err, %s", err)
 			fs.shutdownCh <- struct{}{}

--- a/pkg/reducestreamer/service.go
+++ b/pkg/reducestreamer/service.go
@@ -96,7 +96,6 @@ readLoop:
 			break
 		}
 		if errors.Is(err, io.EOF) {
-			log.Printf("EOF received, stopping the ReduceStreamFn")
 			taskManager.CloseAll()
 			// wait for all tasks to complete and close output channel
 			taskManager.WaitAll()
@@ -140,7 +139,7 @@ readLoop:
 	}
 
 	// wait for all goroutines to finish
-	if err := g.Wait(); err != nil {
+	if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
 		fs.once.Do(func() {
 			log.Printf("Stopping the ReduceStreamFn with err, %s", err)
 			fs.shutdownCh <- struct{}{}

--- a/pkg/servingstore/service.go
+++ b/pkg/servingstore/service.go
@@ -2,6 +2,7 @@ package servingstore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"runtime/debug"
@@ -59,7 +60,7 @@ func (s *Service) Put(ctx context.Context, request *servingpb.PutRequest) (*serv
 	})
 
 	err := g.Wait()
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		s.once.Do(func() {
 			s.shutdownCh <- struct{}{}
 		})
@@ -96,7 +97,7 @@ func (s *Service) Get(ctx context.Context, request *servingpb.GetRequest) (*serv
 	})
 
 	err := g.Wait()
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		s.once.Do(func() {
 			s.shutdownCh <- struct{}{}
 		})

--- a/pkg/sessionreducer/service.go
+++ b/pkg/sessionreducer/service.go
@@ -89,7 +89,6 @@ readLoop:
 			break
 		}
 		if errors.Is(err, io.EOF) {
-			log.Printf("EOF received, stopping the SessionReduceFn")
 			taskManager.WaitAll()
 			taskManager.CloseErrorChannel()
 			break readLoop
@@ -138,7 +137,7 @@ readLoop:
 	}
 
 	// wait for all goroutines to finish
-	if err := g.Wait(); err != nil {
+	if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
 		fs.once.Do(func() {
 			log.Printf("Stopping the SessionReduceFn with err, %s", err)
 			fs.shutdownCh <- struct{}{}

--- a/pkg/sourcetransformer/service.go
+++ b/pkg/sourcetransformer/service.go
@@ -107,7 +107,6 @@ outer:
 			break outer
 		}
 		if errors.Is(err, io.EOF) {
-			log.Printf("EOF received, stopping the SourceTransformFn")
 			break outer
 		}
 		if err != nil {
@@ -124,7 +123,7 @@ outer:
 	}
 
 	// wait for all the goroutines to finish, if any of the goroutines return an error, wait will return that error immediately.
-	if err := grp.Wait(); err != nil {
+	if err := grp.Wait(); err != nil && !errors.Is(err, context.Canceled) {
 		fs.once.Do(func() {
 			log.Printf("Stopping the SourceTransformFn with err, %s", err)
 			fs.shutdownCh <- struct{}{}


### PR DESCRIPTION
### Problem
Client cancellation was triggering server shutdown and udf container restart.

### Fix
If the error type is `context.Cancelled` we don't send shutdown signal to the server.