### PR TITLE
fix: use the closed window in the eof response

### DIFF
--- a/pkg/accumulator/service_test.go
+++ b/pkg/accumulator/service_test.go
@@ -3,6 +3,7 @@ package accumulator
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 
 	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	accumulatorpb "github.com/numaproj/numaflow-go/pkg/apis/proto/accumulator/v1"
 )
@@ -163,4 +165,169 @@ func TestService_AccumulateFn_Panic(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		t.Error("Expected shutdown channel to be triggered, but it wasn't")
 	}
+}
+
+func TestService_AccumulateFn_EOFEchoesCloseWindow(t *testing.T) {
+	svc := &Service{
+		AccumulatorCreator: SimpleCreatorWithAccumulateFn(func(ctx context.Context, input <-chan Datum, output chan<- Message) {
+			for datum := range input {
+				output <- MessageFromDatum(datum)
+			}
+		}),
+		shutdownCh: make(chan struct{}, 1),
+	}
+	conn := newTestServer(t, func(server *grpc.Server) {
+		accumulatorpb.RegisterAccumulatorServer(server, svc)
+	})
+
+	client := accumulatorpb.NewAccumulatorClient(conn)
+	stream, err := client.AccumulateFn(context.Background())
+	require.NoError(t, err, "Creating stream")
+
+	keys := []string{"k1"}
+	openWindow := &accumulatorpb.KeyedWindow{
+		Start: timestamppb.New(time.UnixMilli(0)),
+		End:   timestamppb.New(time.UnixMilli(60000)),
+		Slot:  "slot-0",
+		Keys:  keys,
+	}
+
+	// OPEN
+	require.NoError(t, stream.Send(&accumulatorpb.AccumulatorRequest{
+		Payload: &accumulatorpb.Payload{
+			Keys:      keys,
+			Value:     []byte("v1"),
+			EventTime: timestamppb.New(time.UnixMilli(1000)),
+			Watermark: timestamppb.New(time.UnixMilli(1000)),
+		},
+		Operation: &accumulatorpb.AccumulatorRequest_WindowOperation{
+			Event:       accumulatorpb.AccumulatorRequest_WindowOperation_OPEN,
+			KeyedWindow: openWindow,
+		},
+	}), "Sending OPEN")
+
+	// APPEND
+	require.NoError(t, stream.Send(&accumulatorpb.AccumulatorRequest{
+		Payload: &accumulatorpb.Payload{
+			Keys:      keys,
+			Value:     []byte("v2"),
+			EventTime: timestamppb.New(time.UnixMilli(2000)),
+			Watermark: timestamppb.New(time.UnixMilli(2000)),
+		},
+		Operation: &accumulatorpb.AccumulatorRequest_WindowOperation{
+			Event:       accumulatorpb.AccumulatorRequest_WindowOperation_APPEND,
+			KeyedWindow: openWindow,
+		},
+	}), "Sending APPEND")
+
+	// CLOSE with a distinct window that must be echoed in the EOF response.
+	closeWindow := &accumulatorpb.KeyedWindow{
+		Start: timestamppb.New(time.UnixMilli(1000000)),
+		End:   timestamppb.New(time.UnixMilli(2000000)),
+		Slot:  "slot-7",
+		Keys:  keys,
+	}
+	require.NoError(t, stream.Send(&accumulatorpb.AccumulatorRequest{
+		Operation: &accumulatorpb.AccumulatorRequest_WindowOperation{
+			Event:       accumulatorpb.AccumulatorRequest_WindowOperation_CLOSE,
+			KeyedWindow: closeWindow,
+		},
+	}), "Sending CLOSE")
+
+	// Read responses on the still-open stream until we get the EOF response, mirroring how
+	// numaflow-core reads the per-window EOF while the bidi stream stays open. Assert it
+	// echoes the CLOSE window.
+	var eof *accumulatorpb.AccumulatorResponse
+	for {
+		resp, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err, "Receiving response")
+		if resp.GetEOF() {
+			eof = resp
+			break
+		}
+	}
+
+	require.NoError(t, stream.CloseSend(), "CloseSend")
+
+	require.NotNil(t, eof, "Expected an EOF response")
+	w := eof.GetWindow()
+	require.NotNil(t, w, "EOF response must carry a window")
+	assert.Equal(t, closeWindow.GetStart().GetSeconds(), w.GetStart().GetSeconds(), "EOF window start")
+	assert.Equal(t, closeWindow.GetEnd().GetSeconds(), w.GetEnd().GetSeconds(), "EOF window end")
+	assert.Equal(t, "slot-7", w.GetSlot(), "EOF window slot")
+	assert.Equal(t, keys, w.GetKeys(), "EOF window keys")
+}
+
+// TestService_AccumulateFn_EOFEchoesCloseWindow_NoOutput exercises the WAL-leak scenario:
+// an accumulator that emits nothing must still echo the CLOSE window's end in its EOF
+// response (rather than the never-advanced latest watermark) so core can GC the WAL.
+func TestService_AccumulateFn_EOFEchoesCloseWindow_NoOutput(t *testing.T) {
+	svc := &Service{
+		AccumulatorCreator: SimpleCreatorWithAccumulateFn(func(ctx context.Context, input <-chan Datum, output chan<- Message) {
+			for range input {
+				// intentionally emit nothing
+			}
+		}),
+		shutdownCh: make(chan struct{}, 1),
+	}
+	conn := newTestServer(t, func(server *grpc.Server) {
+		accumulatorpb.RegisterAccumulatorServer(server, svc)
+	})
+
+	client := accumulatorpb.NewAccumulatorClient(conn)
+	stream, err := client.AccumulateFn(context.Background())
+	require.NoError(t, err, "Creating stream")
+
+	keys := []string{"k1"}
+	openWindow := &accumulatorpb.KeyedWindow{
+		Start: timestamppb.New(time.UnixMilli(0)),
+		End:   timestamppb.New(time.UnixMilli(60000)),
+		Slot:  "slot-0",
+		Keys:  keys,
+	}
+
+	// OPEN with a payload (no output will be produced).
+	require.NoError(t, stream.Send(&accumulatorpb.AccumulatorRequest{
+		Payload: &accumulatorpb.Payload{
+			Keys:      keys,
+			Value:     []byte("v1"),
+			EventTime: timestamppb.New(time.UnixMilli(1000)),
+			Watermark: timestamppb.New(time.UnixMilli(1000)),
+		},
+		Operation: &accumulatorpb.AccumulatorRequest_WindowOperation{
+			Event:       accumulatorpb.AccumulatorRequest_WindowOperation_OPEN,
+			KeyedWindow: openWindow,
+		},
+	}), "Sending OPEN")
+
+	closeWindow := &accumulatorpb.KeyedWindow{
+		Start: timestamppb.New(time.UnixMilli(1000000)),
+		End:   timestamppb.New(time.UnixMilli(2000000)),
+		Slot:  "slot-7",
+		Keys:  keys,
+	}
+	require.NoError(t, stream.Send(&accumulatorpb.AccumulatorRequest{
+		Operation: &accumulatorpb.AccumulatorRequest_WindowOperation{
+			Event:       accumulatorpb.AccumulatorRequest_WindowOperation_CLOSE,
+			KeyedWindow: closeWindow,
+		},
+	}), "Sending CLOSE")
+
+	// With no output, the very first (and only) response must be the EOF echoing the
+	// CLOSE window.
+	resp, err := stream.Recv()
+	require.NoError(t, err, "Receiving response")
+	require.True(t, resp.GetEOF(), "Expected the first response to be EOF (no output produced)")
+
+	require.NoError(t, stream.CloseSend(), "CloseSend")
+
+	w := resp.GetWindow()
+	require.NotNil(t, w, "EOF response must carry a window")
+	assert.Equal(t, closeWindow.GetEnd().GetSeconds(), w.GetEnd().GetSeconds(), "EOF window end must be the CLOSE window end, not the latest watermark")
+	assert.Equal(t, closeWindow.GetStart().GetSeconds(), w.GetStart().GetSeconds(), "EOF window start")
+	assert.Equal(t, "slot-7", w.GetSlot(), "EOF window slot")
+	assert.Equal(t, keys, w.GetKeys(), "EOF window keys")
 }

--- a/pkg/accumulator/task_manager.go
+++ b/pkg/accumulator/task_manager.go
@@ -25,10 +25,9 @@ type accumulateTask struct {
 	inputCh         chan Datum
 	outputCh        chan Message
 	latestWatermark time.Time
-	// closeWindow is the KeyedWindow carried by the CLOSE request. CloseTask stashes it
-	// before closing inputCh; it is echoed back in the EOF response so numaflow-core can
-	// GC the WAL for the closed window (by its keys and end time). It is nil on the
-	// shutdown path (CloseAll), where the EOF falls back to a synthesized window.
+	// closeWindow is the KeyedWindow carried by the CLOSE request.
+	// It is nil on the shutdown path (CloseAll), where the EOF
+	// falls back to a synthesized window.
 	closeWindow *v1.KeyedWindow
 }
 
@@ -197,8 +196,7 @@ func (atm *accumulatorTaskManager) CloseTask(request *v1.AccumulatorRequest) {
 		log.Panicf("task not found for key: %s", key)
 	}
 
-	// stash the CLOSE window so the EOF response echoes it back, allowing numaflow-core
-	// to GC the WAL for the closed window (by its keys and end time).
+	// stash the CLOSE window so the EOF response echoes it back
 	task.closeWindow = kw
 	close(task.inputCh)
 	delete(atm.tasks, task.uniqueKey())

--- a/pkg/accumulator/task_manager.go
+++ b/pkg/accumulator/task_manager.go
@@ -25,6 +25,11 @@ type accumulateTask struct {
 	inputCh         chan Datum
 	outputCh        chan Message
 	latestWatermark time.Time
+	// closeWindow is the KeyedWindow carried by the CLOSE request. CloseTask stashes it
+	// before closing inputCh; it is echoed back in the EOF response so numaflow-core can
+	// GC the WAL for the closed window (by its keys and end time). It is nil on the
+	// shutdown path (CloseAll), where the EOF falls back to a synthesized window.
+	closeWindow *v1.KeyedWindow
 }
 
 // uniqueKey returns the unique key for the accumulate task to be used in the task manager to identify the task.
@@ -81,15 +86,22 @@ func (atm *accumulatorTaskManager) CreateTask(request *v1.AccumulatorRequest) {
 					return
 				case output, ok := <-task.outputCh:
 					if !ok {
-						// send EOF response to the response channel
-						atm.responseCh <- &v1.AccumulatorResponse{
-							EOF: true,
-							Window: &v1.KeyedWindow{
+						// Echo the CLOSE request's window in the EOF response.
+						// On the shutdown path (CloseAll, no CLOSE received), fall
+						// back to a synthesized window built from the latest watermark.
+						eofWindow := task.closeWindow
+						if eofWindow == nil {
+							eofWindow = &v1.KeyedWindow{
 								Keys:  task.keys,
 								Slot:  "slot-0",
 								Start: timestamppb.New(time.UnixMilli(0)),
 								End:   timestamppb.New(task.latestWatermark),
-							},
+							}
+						}
+						// send EOF response to the response channel
+						atm.responseCh <- &v1.AccumulatorResponse{
+							EOF:    true,
+							Window: eofWindow,
 						}
 						return
 					}
@@ -185,6 +197,9 @@ func (atm *accumulatorTaskManager) CloseTask(request *v1.AccumulatorRequest) {
 		log.Panicf("task not found for key: %s", key)
 	}
 
+	// stash the CLOSE window so the EOF response echoes it back, allowing numaflow-core
+	// to GC the WAL for the closed window (by its keys and end time).
+	task.closeWindow = kw
 	close(task.inputCh)
 	delete(atm.tasks, task.uniqueKey())
 }


### PR DESCRIPTION
Based on rust SDK changes: https://github.com/numaproj/numaflow-rs/pull/177